### PR TITLE
Ignore invalid UTF-8 codes when dumping JSON to string

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -101,7 +101,7 @@ void WriteJSON(const std::string& topLevel, nlohmann::json& json)
 
 		top[topLevel] = json;
 
-		m_mqtt->publish("json", top.dump());
+		m_mqtt->publish("json", top.dump(-1, ' ', false, nlohmann::json::error_handler_t::ignore));
 	}
 }
 


### PR DESCRIPTION
Original issue: MMDVM-Host crashes when a talker alias string contains invalid UTF-8 codes.

```
D: 2026-09-05 00:52:54.317 DMR Slot 1, Talker Alias (Data Format 3, Received 13/13 char): 'JQ3???Masahi'                                                                    
terminate called after throwing an instance of 'nlohmann::json_abi_v3_11_3::detail::type_error'                                                                             
  what():  [json.exception.type_error.316] invalid UTF-8 byte at index 5: 0x95
  Aborted
```

I believe this should fix the crash, but the issue is hard to reproduce.